### PR TITLE
Support Live Encoding of search terms for multiple word searches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ __pycache__/*
 nomic_embed.db
 *.db
 vectors.db.wal
+minilm-v6.gguf

--- a/EmojiFinder.py
+++ b/EmojiFinder.py
@@ -128,6 +128,6 @@ class EmojiFinderSql(EmojiFinderCached):
             params=(search, ))
         if not results.empty:
             return results.query(
-                'version <= 14.0')  ## move this into sql and add index?
+                'version <= 15.0')  ## move this into sql and add index?
         else:
             return pd.DataFrame(columns=['text', 'emoji'])

--- a/EmojiFinder.py
+++ b/EmojiFinder.py
@@ -130,7 +130,7 @@ class EmojiFinderSql(EmojiFinderCached):
         else:
             ##TODO we need to put the variant mapping into the main emoji_df table
             search = emoji.demojize(search)
-            if base_emoji := self.base_emoji_map.get(search):
+            if base_emoji := self.new_emoji_dict(search).get('text'):
                 search = base_emoji
             results = pd.read_sql(
                 "select * from combined_emoji where word = ? and label = base_emoji order by rank_of_search ;",

--- a/EmojiFinder.py
+++ b/EmojiFinder.py
@@ -120,22 +120,12 @@ class EmojiFinderSql(EmojiFinderCached):
         self.base_emoji_map = new_dict.copy()
 
     def top_emojis(self, search):
-        print('top emoji func=')
-        if not emoji.is_emoji(search):
-            search = search.strip().lower()
-            results = pd.read_sql(
-                "select * from combined_emoji where word = ?  and label = base_emoji order by rank_of_search;",
-                con=self.con,
-                params=(search, ))
-        else:
-            ##TODO we need to put the variant mapping into the main emoji_df table
-            search = emoji.demojize(search)
-            if base_emoji := self.new_emoji_dict(search).get('text'):
-                search = base_emoji
-            results = pd.read_sql(
-                "select * from combined_emoji where word = ? and label = base_emoji order by rank_of_search ;",
-                con=self.con,
-                params=(search, ))
+
+        search = search.strip().lower()
+        results = pd.read_sql(
+            "select * from combined_emoji where word = ?  and label = base_emoji order by rank_of_search;",
+            con=self.con,
+            params=(search, ))
         if not results.empty:
             return results.query(
                 'version <= 14.0')  ## move this into sql and add index?

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ I'm using the python `sentence_tranformers` [package available from SBERT](https
 
 The web app now functions in two ways. The first is to precompute everything and store results for one-word search queries in sqlite. This uses *precomputed semantic distance* against a corpus of common english words (now 40,000 words). The top results are stored in a database in `all-mpnet-base-v2_main.db ` along with lookup tables, indices, and views that make looking up a word a [simple sql query](https://github.com/astrowonk/emoji_finder/blob/06ddc28c9f35458dd8d4e772cb9109530e86f616/EmojiFinder.py#L127).
 
-I also have used the `precompute.py` file to generate `all-MiniLM-L6-v2` vectors which I store in the duckdb database `vectors.db`. Then the `LiveSearch` class can use `llama.cpp` to create a vector for the search term, and duckdb can find the most similar emojis using cosine similarity with a short query:
+For longer queries, I used the `precompute.py` file to generate `all-MiniLM-L6-v2` vectors which I store in the duckdb database `vectors.db`, now that DuckDB supports [fixed size arrays](https://duckdb.org/2024/02/13/announcing-duckdb-0100.html#fixed-length-arrays). Then the `LiveSearch` class can use `llama.cpp` to create a vector for the search term (thanks to new [BERT support in llama.cpp](https://github.com/ggerganov/llama.cpp/pull/5423)) and DuckDB can find the most similar emojis using cosine similarity with a short query:
 
 ```sql
   select id,array_cosine_similarity(arr,?::DOUBLE[384]) as similarity,e.* from array_table a left join emoji_df e on a.id = e.idx where label = base_emoji order by similarity desc limit 25;"

--- a/README.md
+++ b/README.md
@@ -9,27 +9,18 @@ Inspired ([nerd sniped?](https://xkcd.com/356/)) by [this post](https://data-fol
 
 I'm using the python `sentence_tranformers` [package available from SBERT](https://www.sbert.net/index.html). This has a variety of [pretrained models suitable](https://www.sbert.net/docs/pretrained_models.htm) for the task of finding a semantic match between a search term and a target. I'm using the `all-mpnet-base-v2` model for the web apps.
 
-In order to get this to run in the low memory environment of [streamlit](https://share.streamlit.io), or on my [own web site under dash](http://marcoshuerta.com/dash/emoji_finder/), I made a version that uses *precomputed semantic distance* against a corpus of common english words (now ~35,000 words). This has the benefit of running with low memory on the web without pytorch, but the search only works for one-word searches. I may try to add common two-word phrases, but I imagine that data set would get large quickly.
+The web app now functions in two ways. The first is to precompute everything and store results for one-word search queries in sqlite. This uses *precomputed semantic distance* against a corpus of common english words (now 40,000 words). The top results are stored in a database in `all-mpnet-base-v2_main.db ` along with lookup tables, indices, and views that make looking up a word a [simple sql query](https://github.com/astrowonk/emoji_finder/blob/06ddc28c9f35458dd8d4e772cb9109530e86f616/EmojiFinder.py#L127).
 
-The `EmojiFinder` class in `EmojiFinderPytorch.py` live encodes the search term, but still has a pre-encoded vectors for the emojis. 
+I also have used the `precompute.py` file to generate `all-MiniLM-L6-v2` vectors which I store in the duckdb database `vectors.db`. Then the `LiveSearch` class can use `llama.cpp` to create a vector for the search term, and duckdb can find the most similar emojis using cosine similarity with a short query:
 
-The dash app also includes a 2D projection of the `sentence_transformer` vectors via [UMAP](https://umap-learn.readthedocs.io/en/latest/). This shows the emojis as they relate to each other semantically. This is limited to 750 emoji on the graph at once, but more will appear as one zooms in on the plotly graph. Clicking on an emoji will display it with a button to copy to the clipboard.
-### Dash App Screen recording
-(older, pre-graph)
+```sql
+  select id,array_cosine_similarity(arr,?::DOUBLE[384]) as similarity,e.* from array_table a left join emoji_df e on a.id = e.idx where label = base_emoji order by similarity desc limit 25;"
+```
 
-https://user-images.githubusercontent.com/13702392/209137437-4014ab8f-ceac-4528-a73d-38147d9f32b4.mp4
-
+The dash app also includes a 2D projection of the `sentence_transformer` vectors via [UMAP](https://umap-learn.readthedocs.io/en/latest/). This shows the emojis as they relate to each other semantically. This is limited to 750 emoji on the graph at once, but more will appear as one zooms in on the plotly graph. Clicking on an emoji will display it with a button to copy to the clipboard. 
 
 
 TODO:
 
-* Make a config file so one can run it with the full pytorch-requiring library (which can handle longer search terms)
-* Add other preferences like filtering max emoji version, and emoji font size. (Currently hardcoded to 14 or lower.)
+* Add other preferences like filtering max emoji version.
 * Enhance the encoded text for emoji? A person with a laptop is called a "technologist"; if that had a better description, the search would be better at finding it. I'd need some alternate description info, however, not in the [python emoji library](https://pypi.org/project/emoji/)
-* Actually use Github issues and not this markdown list.
-~~* Add persistent preferences for surfacing prioritizing which genders and skin tones to put at top of search.~~
-* ~~Make a Dash version for more layout flexibility / persistent preferences. (Maybe)~~
-  * ~~Alternative : Figure out persistent preferences in Streamlit~~. 
-* ~~Group different gender and skin tone variants of the same emoji on the same line. (i.e. include with the top result e.g. :supervillain:)~~
-* ~~Add the scripts that build the pre-computed distances.~~
-* ~~Compute distances with other methods (dot product) and models (pre-computed distances currently using only `all-mpnet-base-v2`)~~

--- a/dash_app.py
+++ b/dash_app.py
@@ -5,13 +5,13 @@ import pandas as pd
 import dash_bootstrap_components as dbc
 
 from EmojiFinder import EmojiFinderSql, SKIN_TONE_SUFFIXES
-from ducklive import DuckTest
+from ducklive import LiveSearch
 from pathlib import Path
 
 parent_dir = Path().absolute().stem
 
 e = EmojiFinderSql(db_name='all-mpnet-base-v2_main.db')
-d = DuckTest(model_path='minilm-v6.gguf')
+d = LiveSearch(model_path='minilm-v6.gguf')
 
 app = Dash(__name__,
            url_base_pathname=f"/dash/{parent_dir}/",

--- a/dash_app.py
+++ b/dash_app.py
@@ -243,8 +243,10 @@ def make_table_row(record, skin_tone, gender, font_size):
 )
 def search_results(search, skin_tone, gender, font_size):
     if search:
-        full_res = d.get_emoji(search)
+        full_res = e.top_emojis(search)
         if full_res.empty:
+            full_res = d.get_emoji(search)
+        if full_res.empty:  # if it's still somehow empty
             return html.H3('No Results')
         res_list = full_res.to_dict('records')
 

--- a/dash_app.py
+++ b/dash_app.py
@@ -59,7 +59,7 @@ tab1_content = dbc.Container(children=[
                 debounce=True,
                 autofocus=True,
                 placeholder=
-                'Search for emoji (mostly limited to single words; or try an emoji like 🎟️)',
+                'Search for emoji or try an emoji like 🎟️.',
             ),
         ],
                        style=STYLE),

--- a/dash_app.py
+++ b/dash_app.py
@@ -5,11 +5,13 @@ import pandas as pd
 import dash_bootstrap_components as dbc
 
 from EmojiFinder import EmojiFinderSql, SKIN_TONE_SUFFIXES
+from ducklive import DuckTest
 from pathlib import Path
 
 parent_dir = Path().absolute().stem
 
 e = EmojiFinderSql(db_name='all-mpnet-base-v2_main.db')
+d = DuckTest(model_path='minilm-v6.gguf')
 
 app = Dash(__name__,
            url_base_pathname=f"/dash/{parent_dir}/",
@@ -241,7 +243,7 @@ def make_table_row(record, skin_tone, gender, font_size):
 )
 def search_results(search, skin_tone, gender, font_size):
     if search:
-        full_res = e.top_emojis(search)
+        full_res = d.get_emoji(search)
         if full_res.empty:
             return html.H3('No Results')
         res_list = full_res.to_dict('records')

--- a/dash_app.py
+++ b/dash_app.py
@@ -248,7 +248,6 @@ def search_results(search, skin_tone, gender, font_size):
             full_res = d.get_emoji(search)
         if full_res.empty:  # if it's still somehow empty
             return html.H3('No Results')
-        res_list = full_res.to_dict('records')
 
         ## remove variants from list
         #full_res = full_res.query("label not in @variants")

--- a/dash_app.py
+++ b/dash_app.py
@@ -251,6 +251,7 @@ def search_results(search, skin_tone, gender, font_size):
                 search = base_emoji
         full_res = e.top_emojis(search)
         if full_res.empty:
+            print("No precomputed results. Using DuckLive")
             full_res = d.get_emoji(search)
         if full_res.empty:  # if it's still somehow empty
             return html.H3('No Results')

--- a/dash_app.py
+++ b/dash_app.py
@@ -126,7 +126,9 @@ Inspired ([nerd sniped?](https://xkcd.com/356/)) by [this post](https://data-fol
 
 I'm using the python `sentence_tranformers` [package available from SBERT](https://www.sbert.net/index.html). This has a variety of [pretrained models suitable](https://www.sbert.net/docs/pretrained_models.htm) for the task of finding a semantic match between a search term and a target. I'm using the `all-mpnet-base-v2` model for the web apps.
 
-In order to get this to run in a low memory environment of a web host, I *precompute semantic distance* against a corpus of common english words from [GloVe](https://nlp.stanford.edu/projects/glove/). This has the benefit of running with low memory on the web without pytorch, but the search only works for one-word searches. I may try to add command two-word phrases, but I imagine that data set would get large fast.
+In order to get this to run in a low memory environment of a web host, I *precompute semantic distance* against a corpus of common english words from [GloVe](https://nlp.stanford.edu/projects/glove/). This has the benefit of running with low memory on the web without pytorch, but the search only works for one-word searches.
+                            
+**February 2024 Update**: Thanks to llama.cpp and vector support in duckdb, I was able to [add multi-word search](https://github.com/astrowonk/emoji_finder/pull/7) I can generate new embeddings with llama.cpp and use the result in duckdb to find the most similar emojis.
 
 The `ComputeDistances` in `precompute.py` file writes to a sqlite database, which I think reduces memory usage. (It can also generate a series of .parquet files.)
 

--- a/dash_app.py
+++ b/dash_app.py
@@ -5,6 +5,7 @@ import pandas as pd
 import dash_bootstrap_components as dbc
 
 from EmojiFinder import EmojiFinderSql, SKIN_TONE_SUFFIXES
+from emoji import demojize, is_emoji
 from ducklive import LiveSearch
 from pathlib import Path
 
@@ -58,8 +59,7 @@ tab1_content = dbc.Container(children=[
                 value='',
                 debounce=True,
                 autofocus=True,
-                placeholder=
-                'Search for emoji or try an emoji like 🎟️.',
+                placeholder='Search for emoji or try an emoji like 🎟️.',
             ),
         ],
                        style=STYLE),
@@ -245,17 +245,15 @@ def make_table_row(record, skin_tone, gender, font_size):
 )
 def search_results(search, skin_tone, gender, font_size):
     if search:
+        if is_emoji(search):
+            search = demojize(search)
+            if base_emoji := e.new_emoji_dict(search).get('text'):
+                search = base_emoji
         full_res = e.top_emojis(search)
         if full_res.empty:
             full_res = d.get_emoji(search)
         if full_res.empty:  # if it's still somehow empty
             return html.H3('No Results')
-
-        ## remove variants from list
-        #full_res = full_res.query("label not in @variants")
-        #  full_res['label'] = full_res['label'].apply(
-        #      lambda x: y if (y := e.base_emoji_map.get(x)) else x)
-        # full_res['label'] = full_res['base_emoji']
         full_res = full_res.drop_duplicates(subset=['label'])
         table_header = [
             html.Thead(html.Tr([html.Th("Description"),

--- a/ducklive.py
+++ b/ducklive.py
@@ -11,9 +11,9 @@ class LiveSearch:
                                      verbose=False)
 
         self.con = duckdb.connect('vectors.db', read_only=True)
+        self.get_emoji = lru_cache(maxsize=None)(self._get_emoji)
 
-    @lru_cache(maxsize=None)
-    def get_emoji(self, text):
+    def _get_emoji(self, text):
         arr = self.model.create_embedding(text)['data'][0]['embedding']
 
         return self.con.sql(

--- a/ducklive.py
+++ b/ducklive.py
@@ -17,5 +17,5 @@ class LiveSearch:
         arr = self.model.create_embedding(text)['data'][0]['embedding']
 
         return self.con.sql(
-            f"select id,array_cosine_similarity(arr,{arr}::DOUBLE[384]) as similarity,e.* from array_table a left join emoji_df e on a.id = e.idx where label = base_emoji order by similarity desc limit 20;"
+            f"select id,array_cosine_similarity(arr,{arr}::DOUBLE[384]) as similarity,e.* from array_table a left join emoji_df e on a.id = e.idx where label = base_emoji order by similarity desc limit 25;"
         ).to_df()

--- a/ducklive.py
+++ b/ducklive.py
@@ -17,5 +17,5 @@ class LiveSearch:
         arr = self.model.create_embedding(text)['data'][0]['embedding']
 
         return self.con.sql(
-            f"select id,array_cosine_similarity(arr,{arr}::DOUBLE[384]) as similarity,e.* from array_table a left join emoji_df e on a.id = e.idx order by similarity desc limit 20;"
+            f"select id,array_cosine_similarity(arr,{arr}::DOUBLE[384]) as similarity,e.* from array_table a left join emoji_df e on a.id = e.idx where label = base_emoji order by similarity desc limit 20;"
         ).to_df()

--- a/ducklive.py
+++ b/ducklive.py
@@ -2,7 +2,7 @@ import duckdb
 import llama_cpp
 
 
-class DuckTest:
+class LiveSearch:
 
     def __init__(self, model_path) -> None:
         self.model = llama_cpp.Llama(model_path=model_path,

--- a/ducklive.py
+++ b/ducklive.py
@@ -15,5 +15,5 @@ class DuckTest:
         arr = self.model.create_embedding(text)['data'][0]['embedding']
 
         return self.con.sql(
-            f"select id,array_cosine_similarity(arr,{arr}::DOUBLE[384]) as similarity,emoji from array_table a left join emoji_df e on a.id = e.idx order by similarity desc limit 20;"
+            f"select id,array_cosine_similarity(arr,{arr}::DOUBLE[384]) as similarity,e.* from array_table a left join emoji_df e on a.id = e.idx order by similarity desc limit 20;"
         ).to_df()

--- a/ducklive.py
+++ b/ducklive.py
@@ -1,0 +1,19 @@
+import duckdb
+import llama_cpp
+
+
+class DuckTest:
+
+    def __init__(self, model_path) -> None:
+        self.model = llama_cpp.Llama(model_path=model_path,
+                                     embedding=True,
+                                     verbose=False)
+
+        self.con = duckdb.connect('vectors.db', read_only=True)
+
+    def get_emoji(self, text):
+        arr = self.model.create_embedding(text)['data'][0]['embedding']
+
+        return self.con.sql(
+            f"select id,array_cosine_similarity(arr,{arr}::DOUBLE[384]) as similarity,emoji from array_table a left join emoji_df e on a.id = e.idx order by similarity desc limit 20;"
+        ).to_df()

--- a/ducklive.py
+++ b/ducklive.py
@@ -1,5 +1,6 @@
 import duckdb
 import llama_cpp
+from functools import lru_cache
 
 
 class LiveSearch:
@@ -11,6 +12,7 @@ class LiveSearch:
 
         self.con = duckdb.connect('vectors.db', read_only=True)
 
+    @lru_cache(maxsize=None)
     def get_emoji(self, text):
         arr = self.model.create_embedding(text)['data'][0]['embedding']
 

--- a/ducklive.py
+++ b/ducklive.py
@@ -17,5 +17,5 @@ class LiveSearch:
         arr = self.model.create_embedding(text)['data'][0]['embedding']
 
         return self.con.sql(
-            f"select id,array_cosine_similarity(arr,{arr}::DOUBLE[384]) as similarity,e.* from array_table a left join emoji_df e on a.id = e.idx where label = base_emoji order by similarity desc limit 25;"
-        ).to_df()
+            "select id,array_cosine_similarity(arr,?::DOUBLE[384]) as similarity,e.* from array_table a left join emoji_df e on a.id = e.idx where label = base_emoji order by similarity desc limit 25;",
+            params=(arr, )).to_df()

--- a/precompute.py
+++ b/precompute.py
@@ -129,7 +129,7 @@ class DuckTest:
                                      embedding=True,
                                      verbose=False)
 
-        self.con = duckdb.connect('vectors.db')
+        self.con = duckdb.connect('vectors.db', read_only=True)
 
     def get_emoji(self, text):
         arr = self.model.create_embedding(text)['data'][0]['embedding']

--- a/precompute.py
+++ b/precompute.py
@@ -121,24 +121,6 @@ class ComputeDistances:
             'index': 'idx'
         }).to_sql('emoji_df', con=con, index=False, if_exists='replace')
 
-
-class DuckTest:
-
-    def __init__(self, model_path) -> None:
-        self.model = llama_cpp.Llama(model_path=model_path,
-                                     embedding=True,
-                                     verbose=False)
-
-        self.con = duckdb.connect('vectors.db', read_only=True)
-
-    def get_emoji(self, text):
-        arr = self.model.create_embedding(text)['data'][0]['embedding']
-
-        return self.con.sql(
-            f"select id,array_cosine_similarity(arr,{arr}::DOUBLE[384]) as similarity,emoji from array_table a left join emoji_df e on a.id = e.idx order by similarity desc limit 20;"
-        ).to_df()
-
-
 if __name__ == '__main__':
 
     import argparse

--- a/precompute.py
+++ b/precompute.py
@@ -120,6 +120,21 @@ class ComputeDistances:
             'index': 'idx'
         }).to_sql('emoji_df', con=con, index=False, if_exists='replace')
 
+
+def make_duckb_vectors():
+    c = ComputeDistances('all-MiniLM-L6-v2')
+    c.make_emoji_vectors()
+    array_list = c.vector_array_emoji_df.values.tolist()
+    con = duckdb.connect('vectors.db')
+    con.sql('CREATE or replace TABLE array_table (id INT, arr double[384])')
+    for i in range(1874):
+        sql = f"insert into array_table values({c.index_to_index[i]},{array_list[i]});"
+        con.sql(sql)
+    con.sql("create index array_id on array_table(id);")
+    con.commit()
+    con.close()
+
+
 if __name__ == '__main__':
 
     import argparse

--- a/precompute.py
+++ b/precompute.py
@@ -6,7 +6,6 @@ import pandas as pd
 import numpy as np
 from sqlalchemy import create_engine
 import duckdb
-import llama_cpp
 
 
 class ComputeDistances:


### PR DESCRIPTION
The current web app only looks up pre-computed results for single word searches, stored in a sqlite database.

With new support for BERT in Llama.cpp and support for vector operations in duckdb 0.10.0, I can now live encode a search term into a vector just with python llama.cpp embedings without needing pytorch.  I can then compute distances from this vector against a database of stored vectors directly in duckdb and surface the most similar results easily, all while not using much memory.

This PR implements this using the [all-MiniLM-L6-v2](https://huggingface.co/spaces/tonyking/sentence-transformers-all-MiniLM-L6-v2) model, since that is supported by llama.cpp and is faster than `all-mpnet-base-v2` which I used to make the precomputed sqlite database.

It only uses this new approach and new model when the existing single word query returns no result. This preserves existing search results, and reduces CPU load since nothing has to be computed for most single-word search terms.

Tagging @archiewood as I know you use the live site regularly! 

